### PR TITLE
Fix saving legacy month data without metadata

### DIFF
--- a/public/app.mjs
+++ b/public/app.mjs
@@ -616,7 +616,28 @@ async function saveMonthData() {
   const monthKey = getCurrentMonthKey();
   const docRef = doc(db, "users", currentUser.uid, "months", monthKey);
 
-  currentMonthData.metadata.updatedAt = new Date();
+  // Ensure metadata exists for legacy data before saving to Firestore
+  if (!currentMonthData.metadata || typeof currentMonthData.metadata !== "object") {
+    currentMonthData.metadata = {
+      createdAt: new Date(),
+      updatedAt: new Date(),
+    };
+  } else {
+    if (!currentMonthData.metadata.createdAt) {
+      currentMonthData.metadata.createdAt = new Date();
+    }
+    currentMonthData.metadata.updatedAt = new Date();
+  }
+
+  // Normalise potential legacy structures to avoid runtime errors
+  if (!Array.isArray(currentMonthData.incomes)) {
+    currentMonthData.incomes = [];
+  }
+
+  if (!Array.isArray(currentMonthData.expenses)) {
+    currentMonthData.expenses = [];
+  }
+
   await setDoc(docRef, currentMonthData);
 }
 


### PR DESCRIPTION
## Summary
- ensure legacy month documents get metadata defaults before persisting
- normalise income and expense arrays when saving migrated data

## Testing
- not run (not available)


------
https://chatgpt.com/codex/tasks/task_e_68e5c4794b3c8326a1ccc0fff58459d8